### PR TITLE
Fix compilation error with latest Idris2

### DIFF
--- a/Idris2Python/Idris2Python/ModuleTemplate.idr
+++ b/Idris2Python/Idris2Python/ModuleTemplate.idr
@@ -55,7 +55,7 @@ generatePyInitFile outputModulePath templatePyInitFilePath pyFFIs = do
 
     Right pyInitFilePath <- coreLift $ copyFile' templatePyInitFilePath outputModulePath
         | Left err => throw $ FileErr "Cannot create module __init__.py file" err
-    Right () <- coreLift $ appendFile pyInitFilePath $ unlines $
+    Right () <- coreLift $ Idris2Python.ModuleTemplate.appendFile pyInitFilePath $ unlines $
             [""] ++ pyFFIImports ++ [""] ++ pyFFIStubInits
         | Left err => throw $ FileErr "Cannot reify __init__.py template file" err
 


### PR DESCRIPTION
Apparently an `appendFile` function was added to `System.File` in Idris 2, resulting in a name conflict and compilation error. Using the fully-qualified name fixes it.